### PR TITLE
A couple of fixes

### DIFF
--- a/pushbullet-gnome@stephencoakley.com/extension.js
+++ b/pushbullet-gnome@stephencoakley.com/extension.js
@@ -85,7 +85,7 @@ function disable() {
     notifications.unregister();
 
     if (_timeoutId != 0) {
-        Mainloop.source_remove(_timeoutId);
+        MainLoop.source_remove(_timeoutId);
         _timeoutId = 0;
     }
 }

--- a/pushbullet-gnome@stephencoakley.com/notifications.js
+++ b/pushbullet-gnome@stephencoakley.com/notifications.js
@@ -3,6 +3,7 @@ const GLib = imports.gi.GLib;
 const Lang = imports.lang;
 const Main = imports.ui.main;
 const MessageTray = imports.ui.messageTray;
+const NotificationDestroyedReason = MessageTray.NotificationDestroyedReason;
 const St = imports.gi.St;
 
 const Pushbullet = imports.misc.extensionUtils.getCurrentExtension();
@@ -30,7 +31,7 @@ const NotificationSource = new Lang.Class({
      * Unregisters the source in the UI.
      */
     unregister: function() {
-        Main.messageTray.remove(this);
+        this.destroy(NotificationDestroyedReason.SOURCE_CLOSED);
     },
 
     showPush: function(push) {


### PR DESCRIPTION
commit f9dbbf6:
I'm not sure what happened to the timer, if it really got stuck in shell's main loop xD

commit 9cbab10:
messageTray.remove(source) does not exist, there is a private _removeSource(source) but I think it's better to call source.destroy(reason) that does more cleanup before calling the private function
